### PR TITLE
docs: align agent/workflow guides with current Agency Swarm API

### DIFF
--- a/.claude/agents/agent-creator.md
+++ b/.claude/agents/agent-creator.md
@@ -1,16 +1,16 @@
 ---
 name: agent-creator
-description: Create complete agent modules with folder structure per Agency Swarm v1.0.0 spec
+description: Create complete agent modules with folder structure per Agency Swarm v1.x spec
 tools: Write, Read, Bash, MultiEdit
 color: green
 model: sonnet
 ---
 
-Create complete agent modules including folders, agent classes, and initial configurations for Agency Swarm v1.0.0 agencies.
+Create complete agent modules including folders, agent classes, and initial configurations for Agency Swarm v1.x agencies (currently v1.7.0).
 
 ## Background
 
-Agency Swarm v1.0.0 uses the OpenAI Agents SDK. Agents are instantiated directly (not subclassed). Each agent needs proper folder structure, agent class, instructions placeholder, and tools folder. All agencies require OpenAI API key.
+Agency Swarm v1.x uses the OpenAI Agents SDK. Agents are instantiated directly (not subclassed). Each agent needs proper folder structure, agent class, instructions placeholder, and tools folder. All agencies require OpenAI API key.
 
 ## Input
 
@@ -19,18 +19,20 @@ Agency Swarm v1.0.0 uses the OpenAI Agents SDK. Agents are instantiated directly
 - Communication flow pattern for the agency
 - Note: Working in parallel with instructions-writer, BEFORE tools-creator
 
-## Exact Folder Structure (v1.0.0)
+## Exact Folder Structure (v1.x)
 
 ```
 ├── example_agent/
 │   ├── __init__.py
 │   ├── agent_name.py       # Agent instantiation
 │   ├── instructions.md     # Placeholder for instructions-writer
+│   ├── files/              # Local files for this agent
 │   └── tools/              # For tools-creator to populate
 ├── example_agent2/
 │   ├── __init__.py
 │   ├── example_agent2.py
 │   ├── instructions.md
+│   ├── files/
 │   └── tools/
 ├── agency.py               # Main agency file
 ├── agency_manifesto.md     # Shared instructions
@@ -41,18 +43,18 @@ Agency Swarm v1.0.0 uses the OpenAI Agents SDK. Agents are instantiated directly
 ## Agent Module Template (example_agent.py)
 
 ```python
-from agents import ModelSettings
-from agency_swarm import Agent
+from agency_swarm import Agent, ModelSettings
 
 example_agent = Agent(
     name="AgentName",
     description="[Agent role from PRD]",
     instructions="./instructions.md",
+    files_folder="./files",
     tools_folder="./tools",
+    model="gpt-5.2",
     model_settings=ModelSettings(
-        model="gpt-4o",
         temperature=0.5,
-        max_completion_tokens=25000,
+        max_tokens=25000,
     ),
 )
 ```
@@ -60,7 +62,7 @@ example_agent = Agent(
 ## Agent **init**.py Template
 
 ```python
-sfrom .example_agent import example_agent
+from .example_agent import example_agent
 
 __all__ = ["example_agent"]
 ```
@@ -109,7 +111,7 @@ if __name__ == "__main__":
 ## Requirements.txt Template
 
 ```
-agency-swarm>=1.0.0
+agency-swarm>=1.7.0
 python-dotenv
 openai>=1.0.0
 pydantic>=2.0.0

--- a/.claude/agents/api-researcher.md
+++ b/.claude/agents/api-researcher.md
@@ -6,11 +6,11 @@ color: purple
 model: sonnet
 ---
 
-Research MCP servers and APIs for Agency Swarm v1.0.0 tool implementation, strongly prioritizing MCP servers.
+Research MCP servers and APIs for Agency Swarm v1.x tool implementation (currently v1.7.0), strongly prioritizing MCP servers.
 
 ## Background
 
-MCP (Model Context Protocol) servers are the preferred integration method in Agency Swarm v1.0.0. They provide:
+MCP (Model Context Protocol) servers are a preferred integration method in Agency Swarm v1.x. They provide:
 
 - Standardized tool interfaces
 - No custom code maintenance
@@ -20,7 +20,7 @@ MCP (Model Context Protocol) servers are the preferred integration method in Age
 
 ## Research Priority
 
-1. **Built-in Tools First**: Built in tools are preferred over MCP servers.
+1. **Built-in Tools First**: If a capability is already covered by built-in hosted tools, prefer those first.
 2. **MCP Servers First**: Always check for existing MCP servers
 3. **Official MCP Registry**: https://github.com/modelcontextprotocol/servers
 4. **NPM Packages**: Search `@modelcontextprotocol/*`
@@ -47,7 +47,7 @@ Common MCP servers to check for:
 Agency Swarm has a built-in tool for web searchs. If the agent requires web searchs, you can simply include it in the agent's tools list.
 
 ```python
-from agents.tool import WebSearchTool
+from agency_swarm import WebSearchTool
 
 tools = [WebSearchTool()]
 ```
@@ -161,7 +161,7 @@ Create `agency_name/api_docs.md`:
 - MCP servers found: [count]
 - Traditional APIs needed: [count]
 - Total API keys required:
-  - OPENAI_API_KEY (always) - $5 minimum
+  - OPENAI_API_KEY (always required)
   - [List other keys with cost notes]
 ```
 

--- a/.claude/agents/api-researcher.md
+++ b/.claude/agents/api-researcher.md
@@ -161,7 +161,7 @@ Create `agency_name/api_docs.md`:
 - MCP servers found: [count]
 - Traditional APIs needed: [count]
 - Total API keys required:
-  - OPENAI_API_KEY (always required)
+  - OPENAI_API_KEY (always) - $5 minimum
   - [List other keys with cost notes]
 ```
 

--- a/.claude/agents/instructions-writer.md
+++ b/.claude/agents/instructions-writer.md
@@ -6,7 +6,7 @@ color: yellow
 model: sonnet
 ---
 
-Write and refine Agency Swarm v1.0.0 agent instructions using prompt engineering best practices for maximum clarity and performance.
+Write and refine Agency Swarm v1.x agent instructions (currently v1.7.0) using prompt engineering best practices for maximum clarity and performance.
 
 ## Background
 Agency Swarm agents need clear, actionable instructions that follow prompt engineering best practices. Instructions must be specific, example-driven, and integrate tools directly into numbered steps. Working in parallel with agent-creator and tools-creator during initial creation.
@@ -34,7 +34,7 @@ Based on best practices:
 - Specific failures to address
 - Performance metrics to improve
 
-## Instructions Template (v1.0.0)
+## Instructions Template (v1.x)
 ```markdown
 # Role
 You are **[specific role from PRD, e.g., "a data analysis expert specializing in financial reports"]**

--- a/.claude/agents/prd-creator.md
+++ b/.claude/agents/prd-creator.md
@@ -6,15 +6,15 @@ color: blue
 model: sonnet
 ---
 
-Create Product Requirements Documents for Agency Swarm v1.0.0 agencies, optimized for parallel agent creation.
+Create Product Requirements Documents for Agency Swarm v1.x agencies (currently v1.7.0), optimized for parallel agent creation.
 
 ## Background
-Agency Swarm v1.0.0 is built on OpenAI's Agents SDK. Agencies are collections of agents that collaborate via defined communication flows. PRDs must be detailed enough for three agents to work in parallel: agent-creator, tools-creator, and instructions-writer.
+Agency Swarm v1.x is built on OpenAI's Agents SDK. Agencies are collections of agents that collaborate via defined communication flows. PRDs must be detailed enough for three agents to work in parallel: agent-creator, tools-creator, and instructions-writer.
 
 ## Input
 - User concept/idea with clarified goals
 - API/MCP documentation path: `agency_name/api_docs.md`
-- Framework version: Agency Swarm v1.0.0
+- Framework version: Agency Swarm v1.x (current: v1.7.0)
 - Preferred communication pattern
 
 ## Key Design Principles
@@ -45,7 +45,7 @@ CEO → Worker3 (reporting)
 Best for: ETL, document processing, staged workflows
 ```
 Collector → Processor → Publisher
-(with SendMessageHandoff for automatic handoffs)
+(with `Handoff` for automatic handoffs)
 ```
 
 ### 3. Collaborative Network (5% of cases)
@@ -146,13 +146,13 @@ communication_flows = [
   - OPENAI_API_KEY (always required)
   - [Additional keys from tools]
 - **Python Packages**:
-  - agency-swarm>=1.0.0
+  - agency-swarm>=1.7.0
   - python-dotenv
   - [Tool-specific packages]
 
 ## Success Metrics
 - [ ] All agents respond to their designated tasks
-- [ ] Communication flows work bidirectionally
+- [ ] Communication flows are directional and match the intended delegation paths
 - [ ] Error messages are clear and actionable
 - [ ] Response time under [X] seconds
 - [ ] MCP servers initialize correctly

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -41,8 +41,7 @@ agency = Agency(
 if __name__ == "__main__":
     # Test with programmatic interface
     response = agency.get_response_sync("test query")
-    output = response.final_output if hasattr(response, "final_output") else response
-    print(output)
+    print(response.final_output)
 ```
 
 ### 2. Quick Validation
@@ -77,8 +76,7 @@ for i, query in enumerate(test_queries, 1):
     print(f"\n=== Test {i} ===")
     print(f"Query: {query}")
     response = agency.get_response_sync(query)
-    output = response.final_output if hasattr(response, "final_output") else response
-    print(f"Response: {output}")
+    print(f"Response: {response.final_output}")
     # Document response quality, accuracy, completeness
 ```
 

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -41,7 +41,8 @@ agency = Agency(
 if __name__ == "__main__":
     # Test with programmatic interface
     response = agency.get_response_sync("test query")
-    print(response.final_output)
+    output = response.final_output if hasattr(response, "final_output") else response
+    print(output)
 ```
 
 ### 2. Quick Validation
@@ -76,7 +77,8 @@ for i, query in enumerate(test_queries, 1):
     print(f"\n=== Test {i} ===")
     print(f"Query: {query}")
     response = agency.get_response_sync(query)
-    print(f"Response: {response.final_output}")
+    output = response.final_output if hasattr(response, "final_output") else response
+    print(f"Response: {output}")
     # Document response quality, accuracy, completeness
 ```
 

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -9,7 +9,7 @@ model: sonnet
 Wire agency components and test with 5 realistic queries, then provide specific improvement suggestions.
 
 ## Background
-Agency Swarm v1.0.0 testing focuses on real-world usage. Tools are already tested by tools-creator. Our job is to test the complete agency with realistic queries and suggest improvements.
+Agency Swarm v1.x testing focuses on real-world usage. Tools are already tested by tools-creator. Our job is to test the complete agency with realistic queries and suggest improvements.
 
 ## Prerequisites
 - API keys already collected and in .env
@@ -40,8 +40,8 @@ agency = Agency(
 
 if __name__ == "__main__":
     # Test with programmatic interface
-    response = agency.get_completion("test query")
-    print(response)
+    response = agency.get_response_sync("test query")
+    print(response.final_output)
 ```
 
 ### 2. Quick Validation
@@ -75,8 +75,8 @@ test_queries = [
 for i, query in enumerate(test_queries, 1):
     print(f"\n=== Test {i} ===")
     print(f"Query: {query}")
-    response = agency.get_completion(query)
-    print(f"Response: {response}")
+    response = agency.get_response_sync(query)
+    print(f"Response: {response.final_output}")
     # Document response quality, accuracy, completeness
 ```
 

--- a/.claude/agents/tools-creator.md
+++ b/.claude/agents/tools-creator.md
@@ -218,9 +218,11 @@ class QueryDatabase(BaseTool):
         context = query_database(self.question)
 
         # Store in agency context for other tools to use
-        assert self.context is not None
-        self.context.set('context', context)
-        self.context.set('query_timestamp', datetime.now())
+        agency_context = self.context
+        if agency_context is None:
+            raise RuntimeError("Agency context is unavailable.")
+        agency_context.set('context', context)
+        agency_context.set('query_timestamp', datetime.now())
 
         return "Context retrieved and stored successfully."
 ```
@@ -234,9 +236,11 @@ class GenerateReport(BaseTool):
 
     def run(self):
         # Get data from agency context
-        assert self.context is not None
-        context = self.context.get('context')
-        timestamp = self.context.get('query_timestamp')
+        agency_context = self.context
+        if agency_context is None:
+            raise RuntimeError("Agency context is unavailable.")
+        context = agency_context.get('context')
+        timestamp = agency_context.get('query_timestamp')
 
         if not context:
             raise ValueError("No context found. Please run QueryDatabase first.")
@@ -254,16 +258,18 @@ class Action2(BaseTool):
 
     def run(self):
         # Check if previous action completed
-        assert self.context is not None
-        if self.context.get("action_1_complete") is not True:
+        agency_context = self.context
+        if agency_context is None:
+            raise RuntimeError("Agency context is unavailable.")
+        if agency_context.get("action_1_complete") is not True:
             raise ValueError("Please complete Action1 first before proceeding.")
 
         # Perform action
         result = self.perform_action(self.input)
 
         # Mark this action as complete
-        self.context.set("action_2_complete", True)
-        self.context.set("action_2_result", result)
+        agency_context.set("action_2_complete", True)
+        agency_context.set("action_2_result", result)
 
         return "Action 2 completed successfully."
 ```

--- a/.claude/agents/tools-creator.md
+++ b/.claude/agents/tools-creator.md
@@ -218,11 +218,8 @@ class QueryDatabase(BaseTool):
         context = query_database(self.question)
 
         # Store in agency context for other tools to use
-        agency_context = self.context
-        if agency_context is None:
-            raise RuntimeError("Agency context is unavailable.")
-        agency_context.set('context', context)
-        agency_context.set('query_timestamp', datetime.now())
+        self.context.set('context', context)
+        self.context.set('query_timestamp', datetime.now())
 
         return "Context retrieved and stored successfully."
 ```
@@ -236,11 +233,8 @@ class GenerateReport(BaseTool):
 
     def run(self):
         # Get data from agency context
-        agency_context = self.context
-        if agency_context is None:
-            raise RuntimeError("Agency context is unavailable.")
-        context = agency_context.get('context')
-        timestamp = agency_context.get('query_timestamp')
+        context = self.context.get('context')
+        timestamp = self.context.get('query_timestamp')
 
         if not context:
             raise ValueError("No context found. Please run QueryDatabase first.")
@@ -258,18 +252,15 @@ class Action2(BaseTool):
 
     def run(self):
         # Check if previous action completed
-        agency_context = self.context
-        if agency_context is None:
-            raise RuntimeError("Agency context is unavailable.")
-        if agency_context.get("action_1_complete") is not True:
+        if self.context.get("action_1_complete") is not True:
             raise ValueError("Please complete Action1 first before proceeding.")
 
         # Perform action
         result = self.perform_action(self.input)
 
         # Mark this action as complete
-        agency_context.set("action_2_complete", True)
-        agency_context.set("action_2_result", result)
+        self.context.set("action_2_complete", True)
+        self.context.set("action_2_result", result)
 
         return "Action 2 completed successfully."
 ```

--- a/.claude/agents/tools-creator.md
+++ b/.claude/agents/tools-creator.md
@@ -40,6 +40,7 @@ filesystem_server = MCPServerStdio(
         command="npx",
         args=["-y", "@modelcontextprotocol/server-filesystem", "."],
     ),
+    name="Filesystem_Server",  # Tools accessed as Filesystem_Server.read_file
     cache_tools_list=True
 )
 
@@ -68,6 +69,7 @@ github_server = MCPServerStdio(
         args=["-y", "@modelcontextprotocol/server-github"],
         env={"GITHUB_TOKEN": os.getenv("GITHUB_TOKEN")},
     ),
+    name="GitHub_Server",
     cache_tools_list=True
 )
 
@@ -78,6 +80,7 @@ slack_server = MCPServerStdio(
         args=["-y", "@modelcontextprotocol/server-slack"],
         env={"SLACK_TOKEN": os.getenv("SLACK_TOKEN")},
     ),
+    name="Slack_Server",
     cache_tools_list=True
 )
 ```

--- a/.claude/agents/tools-creator.md
+++ b/.claude/agents/tools-creator.md
@@ -6,11 +6,11 @@ color: orange
 model: sonnet
 ---
 
-Implement production-ready Agency Swarm v1.0.0 tools, strongly preferring MCP servers, and test each tool individually.
+Implement production-ready Agency Swarm v1.x tools (currently v1.7.0), strongly preferring MCP servers, and test each tool individually.
 
 ## Background
 
-Agency Swarm v1.0.0 strongly prefers MCP (Model Context Protocol) servers. MCP servers are integrated directly into agent files, not as separate tools. Runs AFTER agent-creator and instructions-writer complete.
+Agency Swarm v1.x strongly prefers MCP (Model Context Protocol) servers. Local MCP servers are integrated directly into agent files via `mcp_servers`; hosted MCP servers can be attached as tools. Runs AFTER agent-creator and instructions-writer complete.
 
 ## Input
 
@@ -31,16 +31,15 @@ Read the API docs to find which MCP servers are available for the required tools
 For each agent that needs MCP tools, MODIFY the agent's .py file:
 
 ```python
-from agency_swarm import Agent
-from agency_swarm.tools.mcp import MCPServerStdio
+from agents.mcp.server import MCPServerStdio, MCPServerStdioParams
+from agency_swarm import Agent, ModelSettings
 
 # Define MCP server
 filesystem_server = MCPServerStdio(
-    name="Filesystem_Server",  # Tools accessed as Filesystem_Server.read_file
-    params={
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
-    },
+    MCPServerStdioParams(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-filesystem", "."],
+    ),
     cache_tools_list=True
 )
 
@@ -51,10 +50,10 @@ agent_name = Agent(
     instructions="./instructions.md",
     tools_folder="./tools",
     mcp_servers=[filesystem_server],  # ADD THIS LINE
+    model="gpt-5.2",
     model_settings=ModelSettings(
-        model="gpt-4o",
         temperature=0.5,
-        max_completion_tokens=25000,
+        max_tokens=25000,
     ),
 )
 ```
@@ -64,23 +63,21 @@ agent_name = Agent(
 ```python
 # GitHub Server
 github_server = MCPServerStdio(
-    name="GitHub_Server",
-    params={
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-github"],
-        "env": {"GITHUB_TOKEN": os.getenv("GITHUB_TOKEN")},
-    },
+    MCPServerStdioParams(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env={"GITHUB_TOKEN": os.getenv("GITHUB_TOKEN")},
+    ),
     cache_tools_list=True
 )
 
 # Slack Server (if available)
 slack_server = MCPServerStdio(
-    name="Slack_Server",
-    params={
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-slack"],
-        "env": {"SLACK_TOKEN": os.getenv("SLACK_TOKEN")},
-    },
+    MCPServerStdioParams(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-slack"],
+        env={"SLACK_TOKEN": os.getenv("SLACK_TOKEN")},
+    ),
     cache_tools_list=True
 )
 ```
@@ -90,7 +87,7 @@ slack_server = MCPServerStdio(
 You can use the following built-in tool when agent requires web searchs:
 
 ```python
-from agents.tool import WebSearchTool
+from agency_swarm import WebSearchTool
 
 tools = [WebSearchTool()]
 ```
@@ -190,39 +187,40 @@ class EmailSender(BaseTool):
     recipient: EmailStr = Field(..., description="Valid email address.")
 ```
 
-### 4. Use Shared State for Flow Control
+### 4. Use Agency Context for Flow Control
 
-Shared state is a centralized dictionary accessible by all tools and agents. Use it to share data without parameter passing.
+Agency context (formerly called shared state) is a centralized store accessible by all tools and agents. Use it to share data without parameter passing.
 
-#### Shared State Key Concepts
+#### Agency Context Key Concepts
 
-- **Shared State**: All tools within an agency share a Python dictionary (`self._shared_state`)
+- **Agency Context**: BaseTools access shared context via `self.context`; FunctionTools use `ctx.context`
 - **Data Sharing**: Tools can exchange data without explicit parameter passing
-- **Flow Control**: Use shared state to enforce tool execution order
-- **Note**: Shared state only works when tools are deployed with agents (not as separate APIs)
+- **Flow Control**: Use agency context to enforce tool execution order
+- **Note**: Agency context only works when tools are deployed with agents (not as separate APIs)
 
-#### Common Shared State Patterns
+#### Common Agency Context Patterns
 
 1. **Data Collection → Processing**: Tool A collects data, Tool B processes it
 2. **Multi-Step Workflows**: Each tool marks its completion for the next
 3. **Session Management**: Store user session data across tools
-4. **Cache Results**: Avoid redundant API calls by caching in shared state
+4. **Cache Results**: Avoid redundant API calls by caching in agency context
 5. **Error Context**: Store error details for debugging across tools
 
 **Setting values**:
 
 ```python
 class QueryDatabase(BaseTool):
-    """Retrieves data and stores it in shared state."""
+    """Retrieves data and stores it in agency context."""
     question: str = Field(..., description="The query to execute.")
 
     def run(self):
         # Fetch data
         context = query_database(self.question)
 
-        # Store in shared state for other tools to use
-        self._shared_state.set('context', context)
-        self._shared_state.set('query_timestamp', datetime.now())
+        # Store in agency context for other tools to use
+        assert self.context is not None
+        self.context.set('context', context)
+        self.context.set('query_timestamp', datetime.now())
 
         return "Context retrieved and stored successfully."
 ```
@@ -231,13 +229,14 @@ class QueryDatabase(BaseTool):
 
 ```python
 class GenerateReport(BaseTool):
-    """Generates report using data from shared state."""
+    """Generates report using data from agency context."""
     format: str = Field(..., description="Report format")
 
     def run(self):
-        # Get data from shared state
-        context = self._shared_state.get('context')
-        timestamp = self._shared_state.get('query_timestamp')
+        # Get data from agency context
+        assert self.context is not None
+        context = self.context.get('context')
+        timestamp = self.context.get('query_timestamp')
 
         if not context:
             raise ValueError("No context found. Please run QueryDatabase first.")
@@ -255,15 +254,16 @@ class Action2(BaseTool):
 
     def run(self):
         # Check if previous action completed
-        if self._shared_state.get("action_1_complete") != True:
+        assert self.context is not None
+        if self.context.get("action_1_complete") is not True:
             raise ValueError("Please complete Action1 first before proceeding.")
 
         # Perform action
         result = self.perform_action(self.input)
 
         # Mark this action as complete
-        self._shared_state.set("action_2_complete", True)
-        self._shared_state.set("action_2_result", result)
+        self.context.set("action_2_complete", True)
+        self.context.set("action_2_result", result)
 
         return "Action 2 completed successfully."
 ```
@@ -316,7 +316,7 @@ class DataProcessor(BaseTool):
 3. **Implement MCP Servers** (CRITICAL):
 
    - Open the agent's .py file
-   - Import MCPServerStdio at the top
+   - Import `MCPServerStdio` and `MCPServerStdioParams` from `agents.mcp.server`
    - Define the MCP server instance
    - Add `mcp_servers=[server_instance]` to Agent()
    - Test that the server initializes
@@ -344,8 +344,8 @@ class DataProcessor(BaseTool):
      - Add chain-of-thought for complex tools
      - Provide helpful error messages
      - Use specific types (Literal, EmailStr)
-     - Implement shared state for data passing between tools
-     - Add flow validation using shared state
+     - Implement agency context for data passing between tools
+     - Add flow validation using agency context
      - Include proper test cases
    - If not working, fix the issue
    - Keep iterating until all tools pass tests
@@ -391,6 +391,6 @@ Report back:
   - Chain-of-thought tools: [count]
   - Tools with type restrictions: [count]
   - Tools with helpful error hints: [count]
-  - Shared state usage: [tools using it]
+  - Agency context usage: [tools using it]
   - All tools have test cases: Yes/No
 - Dependencies added to requirements.txt

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -217,18 +217,19 @@ if __name__ == "__main__":
 
 Remember, each tool code snippet you create must be IMMIDIATELY ready to use by the user. It must not contain any mocks, placeholders or hypothetical examples.
 
-#### Agency Context (Shared State)
+#### Agency Context (formerly Shared State)
 
 Agency context lets your tools and agents share data without passing it in conversation messages.
 
 ```python
 from agency_swarm.tools import BaseTool
+from pydantic import Field
 
 class MyTool(BaseTool):
     value: str = Field(..., description="The value to store in the context")
     def run(self):
-        self._context.set("my_key", self.value)
-        data = self._context.get("my_key", "default")
+        self.context.set("my_key", self.value)
+        data = self.context.get("my_key", "default")
         return data
 ```
 
@@ -249,15 +250,15 @@ Best practices:
 Alternatively to creating custom tools, you can use special MCP servers which already contain predefined tools. In this case, you don't need to create custom tool files for the same functionality or add them to the PRD. You can use MCPs interchangeably with custom tools
 
 ```python
-from agents.mcp import MCPServerStdio
+from agents.mcp.server import MCPServerStdio, MCPServerStdioParams
 
 filesystem_server = MCPServerStdio(
+    MCPServerStdioParams(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-filesystem", "."],
+    ),
     # This name determines how the agent accesses the tools (e.g., Filesystem_Server.list_files)
     name="Filesystem_Server",
-    params={
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
-    },
     cache_tools_list=True
 )
 # Attach this server to your Agent via the mcp_servers list:

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -378,7 +378,7 @@ Agencies are collections of agents that work together to achieve a common goal. 
        agency.terminal_demo()
 
        # to test the agency, send a single prompt for testing:
-       # print(agency.get_response_sync("your question here"))
+       # print(agency.get_response_sync("your question here").final_output)
    ```
 
    Agency must export a create_agency method, which is used for deployment.
@@ -414,7 +414,7 @@ The final step is to test each tool and the agency itself, to ensure they are wo
 3. Once all tools are working as expected, you can test the agency by running the following command in your terminal:
 
    ```
-   python -c "from agency import create_agency; agency = create_agency(); print(agency.get_response_sync('your question here'))"
+   python -c "from agency import create_agency; agency = create_agency(); print(agency.get_response_sync('your question here').final_output)"
    ```
 
    If you see a valid agent response printed in the terminal, you have successfully created an agency that works as expected.


### PR DESCRIPTION
## Summary
Targeted fact-check pass against current Agency Swarm docs/source (`VRSEN/agency-swarm`, `main` @ `6290cc9`, v`1.7.0`) with minimal doc edits.

## Changes
- Updated stale Agency Swarm v1.0.0 references to v1.x where appropriate.
- Corrected MCP examples and naming in tool guidance (including explicit server names).
- Updated agency context examples from deprecated shared-state access patterns.
- Updated QA/testing examples from `get_completion` to `get_response_sync(...).final_output`.
- Aligned the primary workflow guide with the same API patterns used in `.claude/agents` docs.

## Files
- `.claude/agents/agent-creator.md`
- `.claude/agents/api-researcher.md`
- `.claude/agents/instructions-writer.md`
- `.claude/agents/prd-creator.md`
- `.claude/agents/qa-tester.md`
- `.claude/agents/tools-creator.md`
- `.cursor/rules/workflow.mdc`

## Scope
No structural rewrites; only factual/API consistency updates.
