### PR TITLE
fix: remove hard-coded model=gpt-5 and bump agency-swarm floor

### DIFF
--- a/example_agent/example_agent.py
+++ b/example_agent/example_agent.py
@@ -1,5 +1,3 @@
-from agents import ModelSettings
-from openai.types.shared import Reasoning
 from agency_swarm import Agent
 
 
@@ -9,12 +7,4 @@ example_agent = Agent(
     instructions="./instructions.md",
     tools_folder="./tools",
     files_folder="./files",
-    model="gpt-5",
-    model_settings=ModelSettings(
-        max_tokens=25000,
-        reasoning=Reasoning(
-            effort="medium",
-            summary="auto",
-        ),
-    ),
 )

--- a/example_agent2/example_agent2.py
+++ b/example_agent2/example_agent2.py
@@ -1,6 +1,5 @@
-from agents import ModelSettings
 from agency_swarm import Agent
-from openai.types.shared import Reasoning
+
 
 example_agent2 = Agent(
     name="ExampleAgent2",
@@ -8,13 +7,5 @@ example_agent2 = Agent(
     instructions="./instructions.md",
     tools_folder="./tools",
     files_folder="./files",
-    model="gpt-5",
-    model_settings=ModelSettings(
-        max_tokens=25000,
-        reasoning=Reasoning(
-            effort="medium",
-            summary="auto",
-        ),
-    ),
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-agency-swarm[fastapi]>=1.2.1
+agency-swarm[fastapi]>=1.9.1
 fastapi
 uvicorn


### PR DESCRIPTION
## Summary

`model="gpt-5"` is hard-coded in both example agents, but the OpenAI Codex backend used for ChatGPT browser-auth in Agent Swarm CLI rejects it:

```
Error code: 400 - The 'gpt-5' model is not supported when using Codex with a ChatGPT account.
```

Every new user whose only available credential is a ChatGPT account gets a 0-token empty response with no visible error.

## Fix

- Drop `model="gpt-5"` from both example agents — agency-swarm's framework default (`gpt-5.4-mini`) is Codex-compatible and works on plain OpenAI API keys too.
- Drop the ModelSettings override (`max_tokens=25000`, custom Reasoning) — framework defaults cover the demo flow.
- Bump `agency-swarm[fastapi]>=1.9.1` so fresh clones pick up the matching browser-auth compatibility and bridge-containment fixes.

## End-user impact

- Before: `agentswarm` → send 'hello' → silent empty response for any ChatGPT OAuth user.
- After: `agentswarm` → send 'hello' → agent replies normally.